### PR TITLE
update product bundle identifier to avoid conflicts with Unbox

### DIFF
--- a/Wrap.xcodeproj/project.pbxproj
+++ b/Wrap.xcodeproj/project.pbxproj
@@ -477,7 +477,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.unbox.Unbox-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.unbox.Wrap-iOS";
 				PRODUCT_NAME = Wrap;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -496,7 +496,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.unbox.Unbox-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.unbox.Wrap-iOS";
 				PRODUCT_NAME = Wrap;
 				SKIP_INSTALL = YES;
 			};
@@ -617,7 +617,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.unbox.Unbox-OSX";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.unbox.Wrap-OSX";
 				PRODUCT_NAME = Wrap;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -638,7 +638,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.unbox.Unbox-OSX";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.unbox.Wrap-OSX";
 				PRODUCT_NAME = Wrap;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Hi,
this fixes issue with Unbox when integrating Wrap via Carthage - it was impossible to install app due to conflicting/same identifiers.
