### PR TITLE
Add default implementation of WrapCustomizable that wraps to snake case

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,30 @@ struct Book: WrapCustomizable {
 
 You can also use the `keyForWrappingPropertyNamed()` API to skip a property entirely, by returning nil from this method for it.
 
+Wrap also provides an implementation of transforming keys from camel case to snake case:
+
+```swift
+struct Book {
+    let title: String
+    let nrOfPages: Int
+    let authorName: String
+    let pictureURL: String?
+}
+
+extension Book: WrapToSnakeCase {}
+```
+
+This will produce the following dictionary when wrapped:
+
+```json
+{
+    "title": "Game of Thrones", 
+    "nr_of_pages": 694,
+    "author_name": "George R. R. Martin",
+    "picture_url": "http://t0.gstatic.com/images?q=tbn:ANd9GcSQl7Kuali9GsWHGLzKX-IvP6tn3T1Pd_qDgMIzloF7gT_t8fAu"
+}
+```
+
 #### Custom key types
 
 You might have nested dictionaries that are not keyed on `Strings`, and for those Wrap provides the `WrappableKey` protocol. This enables you to easily convert any type into a string that can be used as a JSON key.

--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -268,6 +268,22 @@ extension Int: WrappableKey {
     }
 }
 
+// MARK: - Custom Wrap Key Transformations
+
+public protocol WrapToSnakeCase: WrapCustomizable {}
+
+public extension WrapToSnakeCase {
+    func keyForWrappingPropertyNamed(propertyName: String) -> String? {
+        let regex = try! NSRegularExpression(pattern: "(?<=[a-z])([A-Z])|([A-Z])(?=[a-z])",
+                                             options: [])
+        return regex.stringByReplacingMatchesInString(propertyName,
+                                                      options: [],
+                                                      range: NSRange(location: 0, length: propertyName.characters.count),
+                                                      withTemplate: "_$1$2").lowercaseString
+    }
+}
+
+
 // MARK: - Private
 
 private extension Wrapper {

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -713,6 +713,29 @@ class WrapTests: XCTestCase {
     }
 }
 
+// MARK: - Custom Wrap Key Transformations
+
+class WrapToSnakeCaseTests: XCTestCase {
+
+    func test_correctly_wraps_to_snake_case() {
+        struct Book: WrapToSnakeCase {
+            let title: String
+            let nrOfPages: Int
+            let authorName: String
+            let pictureURL: String?
+        }
+        
+        let request = Book(title: "Game of Thrones", nrOfPages: 694, authorName: "George R. R. Martin", pictureURL: "http://www.example.com/got.png")
+        
+        let parameters: [String: AnyObject] = try! Wrap(request)
+        
+        let keys = Set(parameters.keys)
+        
+        XCTAssertEqual(keys, Set(["title", "nr_of_pages", "author_name", "picture_url"]))
+    }
+}
+
+
 // MARK: - Mocks
 
 private protocol MockProtocol {


### PR DESCRIPTION
This PRs adds the `WrapToSnakeCase` protocol which allows an automatic wrapping to snake case. By making a model adopt to the `WrapToSnakeCase` protocol,

``` swift
struct Book {
    let title: String
    let nrOfPages: Int
    let authorName: String
    let pictureURL: String?
}

extension Book: WrapToSnakeCase {}
```

will produce the following dictionary when wrapped:

``` json
{
    "title": "Game of Thrones", 
    "nr_of_pages": 694,
    "author_name": "George R. R. Martin",
    "picture_url": "http://t0.gstatic.com/images?q=tbn:ANd9GcSQl7Kuali9GsWHGLzKX-IvP6tn3T1Pd_qDgMIzloF7gT_t8fAu"
}
```

We wrote this internally because our API expects snake case and thought it might be useful to others. Don't hesitate to say so if you feel like this doesn't belong in the core framework.
