### PR TITLE
Wrap 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7
+osx_image: xcode8
 script:
     - xctool -project Wrap.xcodeproj -scheme Wrap-iOS clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
     - xctool -project Wrap.xcodeproj -scheme Wrap-watchOS clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 osx_image: xcode8
 script:
-    - xctool -project Wrap.xcodeproj -scheme Wrap-iOS clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-    - xctool -project Wrap.xcodeproj -scheme Wrap-watchOS clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-    - xctool -project Wrap.xcodeproj -scheme Wrap-OSX clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
-    - xctool -project Wrap.xcodeproj -scheme WrapTests clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+    - xcodebuild -project Wrap.xcodeproj -scheme Wrap-iOS clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+    - xcodebuild -project Wrap.xcodeproj -scheme Wrap-watchOS clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+    - xcodebuild -project Wrap.xcodeproj -scheme Wrap-OSX clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+    - xcodebuild -project Wrap.xcodeproj -scheme WrapTests clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ You can also use the `keyForWrapping(propertyNamed:)` API to skip a property ent
 
 You might have nested dictionaries that are not keyed on `Strings`, and for those Wrap provides the `WrappableKey` protocol. This enables you to easily convert any type into a string that can be used as a JSON key.
 
+#### Encoding keys as snake_case
+
+If you want the dictionary that Wrap produces to have snake_cased keys rather than the default (which is matching the names of the properties that were encoded), you can easily do so by conforming to `WrapCustomizable` and returning `.convertToSnakeCase` from the `wrapKeyStyle` property. Doing that will, for example, convert the property name `myProperty` into the key `my_property`.
+
 #### Customized wrapping
 
 For some nested types, you might want to handle the wrapping yourself. This may be especially true for any custom collections, or types that have a completely different representation when encoded. To do that, make a type conform to `WrapCustomizable` and implement `wrap()`, like this:
@@ -149,8 +153,8 @@ For some nested types, you might want to handle the wrapping yourself. This may 
 struct Library: WrapCustomizable {
     private let booksByID: [String : Book]
 
-    func wrap() -> Any? {
-        return Wrapper().wrap(self.booksByID)
+    func wrap(context: Any?, dateFormatter: DateFormatter?) -> Any? {
+        return Wrapper(context: context, dateFormatter: dateFormatter).wrap(self.booksByID)
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Wrap is an easy to use Swift JSON encoder. Don't spend hours writing JSON encoding code - just wrap it instead!
 
-Using Wrap is as easy as calling `Wrap()` on any instance of a `class` or `struct` that you wish to encode. It automatically encodes all of your type’s properties, including nested objects, collections, enums and more!
+Using Wrap is as easy as calling `wrap()` on any instance of a `class` or `struct` that you wish to encode. It automatically encodes all of your type’s properties, including nested objects, collections, enums and more!
 
 It also provides a suite of simple but powerful customization APIs that enables you to use it on any model setup with ease.
 
@@ -23,10 +23,10 @@ struct User {
 let user = User(name: "John", age: 28)
 ```
 
-Using `Wrap()` you can now encode a `User` instance with one command:
+Using `wrap()` you can now encode a `User` instance with one command:
 
 ```swift
-let dictionary: [String : AnyObject] = try Wrap(user)
+let dictionary: [String : Any] = try wrap(user)
 ```
 
 Which will produce the following `Dictionary`:
@@ -86,10 +86,10 @@ let ship = SpaceShip(
 )
 ```
 
-And now let’s encode it with one call to `Wrap()`:
+And now let’s encode it with one call to `wrap()`:
 
 ```swift
-let dictionary: WrappedDictionary = try Wrap(ship)
+let dictionary: WrappedDictionary = try wrap(ship)
 ```
 
 Which will produce the following dictionary:
@@ -118,14 +118,14 @@ While automation is awesome, customization is just as important. Thankfully, Wra
 
 #### Customizing keys
 
-Per default Wrap uses the property names of a type as its encoding keys, but sometimes this is not what you’re looking for. You can choose to override any or all of a type’s encoding keys by making it conform to `WrapCustomizable` and implementing `keyForWrappingPropertyNamed`, like this:
+Per default Wrap uses the property names of a type as its encoding keys, but sometimes this is not what you’re looking for. You can choose to override any or all of a type’s encoding keys by making it conform to `WrapCustomizable` and implementing `keyForWrapping(propertyNamed:)`, like this:
 
 ```swift
 struct Book: WrapCustomizable {
     let title: String
     let authorName: String
 
-    func keyForWrappingPropertyNamed(propertyName: String) -> String? {
+    func keyForWrapping(propertyNamed propertyName: String) -> String? {
         if propertyName == "authorName" {
             return "author_name"
         }
@@ -135,7 +135,7 @@ struct Book: WrapCustomizable {
 }
 ```
 
-You can also use the `keyForWrappingPropertyNamed()` API to skip a property entirely, by returning nil from this method for it.
+You can also use the `keyForWrapping(propertyNamed:)` API to skip a property entirely, by returning nil from this method for it.
 
 #### Custom key types
 
@@ -149,7 +149,7 @@ For some nested types, you might want to handle the wrapping yourself. This may 
 struct Library: WrapCustomizable {
     private let booksByID: [String : Book]
 
-    func wrap() -> AnyObject? {
+    func wrap() -> Any? {
         return Wrapper().wrap(self.booksByID)
     }
 }
@@ -163,13 +163,13 @@ Non-raw type `enum` values are also automatically encoded. The default behavior 
 
 ```swift
 enum Profession {
-    case Developer(favoriteLanguageName: String)
-    case Lawyer
+    case developer(favoriteLanguageName: String)
+    case lawyer
 }
 
 struct Person {
-    let profession = Profession.Developer(favoriteLanguageName: "Swift")
-    let hobbyProfession = Profession.Lawyer
+    let profession = Profession.developer(favoriteLanguageName: "Swift")
+    let hobbyProfession = Profession.lawyer
 }
 ```
 
@@ -178,9 +178,9 @@ Encodes into:
 ```json
 {
     "profession": {
-        "Developer": "Swift"
+        "developer": "Swift"
     },
-    "hobbyProfession": "Lawyer"
+    "hobbyProfession": "lawyer"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Clone the repo and drag the file `Wrap.swift` into your Xcode project.
 
 **Swift Package Manager:**
 
-Add the line `.Package(url: "https://github.com/JohnSundell/Wrap.git", majorVersion: 1)` to your `Package.swift` file.
+Add the line `.Package(url: "https://github.com/JohnSundell/Wrap.git", majorVersion: 2)` to your `Package.swift` file.
 
 ### Hope you enjoy wrapping your objects!
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,17 @@ struct Book: WrapCustomizable {
 }
 ```
 
+### Compatibility
+
+Wrap supports all current Apple platforms with the following minimum versions:
+
+- iOS 8
+- (mac)OS (X) 10.11
+- watchOS 2
+- tvOS 9
+
+The current version of Wrap (and the `master` branch) is only compatible with Swift 3 and Xcode 8, however, there’s a [`swift2` branch](https://github.com/JohnSundell/Wrap/tree/swift2) that can be used in apps using Swift 2.3.
+
 ### Installation
 
 **CocoaPods:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wrap
 
-![Travis](https://img.shields.io/travis/JohnSundell/Wrap.svg)
+![Travis](https://img.shields.io/travis/JohnSundell/Wrap/master.svg)
 ![CocoaPods](https://img.shields.io/cocoapods/v/Wrap.svg)
 [![Carthage](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you want the dictionary that Wrap produces to have snake_cased keys rather th
 
 #### Customized wrapping
 
-For some nested types, you might want to handle the wrapping yourself. This may be especially true for any custom collections, or types that have a completely different representation when encoded. To do that, make a type conform to `WrapCustomizable` and implement `wrap()`, like this:
+For some nested types, you might want to handle the wrapping yourself. This may be especially true for any custom collections, or types that have a completely different representation when encoded. To do that, make a type conform to `WrapCustomizable` and implement `wrap(context:dateFormatter:)`, like this:
 
 ```swift
 struct Library: WrapCustomizable {
@@ -185,6 +185,28 @@ Encodes into:
         "developer": "Swift"
     },
     "hobbyProfession": "lawyer"
+}
+```
+
+### Contextual objects
+
+To be able to easily encode any dependencies that you might want to use during the encoding process, Wrap provides the ability to supply a contextual object when initiating the wrapping process (by calling `wrap(object, context: myContext`).
+
+A context can be of `Any` type and is accessible in all `WrapCustomizable` wrapping methods. Here is an example, where we send in a prefix to add to a `Book`’s `title`:
+
+```swift
+struct Book: WrapCustomizable {
+    let title: String
+    
+    func wrap(context: Any?, dateFormatter: DateFormatter?) -> Any? {
+        guard let prefix = context as? String else {
+            return nil
+        }
+        
+        return [
+            "title" : prefix + self.title
+        ]
+    }
 }
 ```
 

--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -424,7 +424,7 @@ private extension Wrapper {
                     continue
                 }
                 
-                guard let propertyName = property.label where propertyName != "Some" else {
+                guard let propertyName = property.label, propertyName != "Some" else {
                     continue
                 }
                 

--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -196,9 +196,9 @@ public class Wrapper {
 /// Error type used by Wrap
 public enum WrapError: Error {
     /// Thrown when an invalid top level object (such as a String or Int) was passed to `Wrap()`
-    case InvalidTopLevelObject(Any)
+    case invalidTopLevelObject(Any)
     /// Thrown when an object couldn't be wrapped. This is a last resort error.
-    case WrappingFailedForObject(Any)
+    case wrappingFailedForObject(Any)
 }
 
 // MARK: - Default protocol implementations
@@ -304,7 +304,7 @@ private extension Wrapper {
                 let wrapped = try self.performCustomWrapping(object: customizable)
                 
                 guard let wrappedDictionary = wrapped as? WrappedDictionary else {
-                    throw WrapError.InvalidTopLevelObject(object)
+                    throw WrapError.invalidTopLevelObject(object)
                 }
                 
                 return wrappedDictionary
@@ -345,7 +345,7 @@ private extension Wrapper {
                         return wrapped
                     }
                     
-                    throw WrapError.WrappingFailedForObject(value)
+                    throw WrapError.wrappingFailedForObject(value)
                 }
                 
                 return "\(value)"
@@ -451,7 +451,7 @@ private extension Wrapper {
     
     func performCustomWrapping(object: WrapCustomizable) throws -> Any {
         guard let wrapped = object.wrap() else {
-            throw WrapError.WrappingFailedForObject(object)
+            throw WrapError.wrappingFailedForObject(object)
         }
         
         return wrapped

--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -69,35 +69,35 @@ public typealias WrappedDictionary = [String : Any]
  *
  *  See also `WrappableKey` (for dictionary keys) and `WrappableEnum` for Enum values.
  */
-public func Wrap<T>(_ object: T, dateFormatter: DateFormatter? = nil) throws -> WrappedDictionary {
+public func wrap<T>(_ object: T, dateFormatter: DateFormatter? = nil) throws -> WrappedDictionary {
     return try Wrapper(dateFormatter: dateFormatter).wrap(object: object, enableCustomizedWrapping: true)
 }
 
 /**
- *  Alternative `Wrap()` overload that returns JSON-based `Data`
+ *  Alternative `wrap()` overload that returns JSON-based `Data`
  *
- *  See the documentation for the dictionary-based `Wrap()` function for more information
+ *  See the documentation for the dictionary-based `wrap()` function for more information
  */
-public func Wrap<T>(_ object: T, writingOptions: JSONSerialization.WritingOptions? = nil, dateFormatter: DateFormatter? = nil) throws -> Data {
+public func wrap<T>(_ object: T, writingOptions: JSONSerialization.WritingOptions? = nil, dateFormatter: DateFormatter? = nil) throws -> Data {
     return try Wrapper(dateFormatter: dateFormatter).wrap(object: object, writingOptions: writingOptions ?? [])
 }
 
 /**
- *  Alternative `Wrap()` overload that encodes an array of objects into an array of dictionaries
+ *  Alternative `wrap()` overload that encodes an array of objects into an array of dictionaries
  *
- *  See the documentation for the dictionary-based `Wrap()` function for more information
+ *  See the documentation for the dictionary-based `wrap()` function for more information
  */
-public func Wrap<T>(_ objects: [T], dateFormatter: DateFormatter? = nil) throws -> [WrappedDictionary] {
-    return try objects.map({ try Wrap($0) })
+public func wrap<T>(_ objects: [T], dateFormatter: DateFormatter? = nil) throws -> [WrappedDictionary] {
+    return try objects.map({ try wrap($0) })
 }
 
 /**
- *  Alternative `Wrap()` overload that encodes an array of objects into JSON-based `Data`
+ *  Alternative `wrap()` overload that encodes an array of objects into JSON-based `Data`
  *
- *  See the documentation for the dictionary-based `Wrap()` function for more information
+ *  See the documentation for the dictionary-based `wrap()` function for more information
  */
-public func Wrap<T>(_ objects: [T], writingOptions: JSONSerialization.WritingOptions? = nil, dateFormatter: DateFormatter? = nil) throws -> Data {
-    let dictionaries: [WrappedDictionary] = try Wrap(objects)
+public func wrap<T>(_ objects: [T], writingOptions: JSONSerialization.WritingOptions? = nil, dateFormatter: DateFormatter? = nil) throws -> Data {
+    let dictionaries: [WrappedDictionary] = try wrap(objects)
     return try JSONSerialization.data(withJSONObject: dictionaries as AnyObject, options: writingOptions ?? [])
 }
 
@@ -114,7 +114,7 @@ public protocol WrapCustomizable {
      *  All top-level types should return a `WrappedDictionary` from this method.
      *
      *  You may use the default wrapping implementation by using a `Wrapper`, but
-     *  never call `Wrap()` from an implementation of this method, since that might
+     *  never call `wrap()` from an implementation of this method, since that might
      *  cause an infinite recursion.
      *
      *  Returning nil from this method will be treated as an error, and cause
@@ -140,7 +140,7 @@ public protocol WrapCustomizable {
      *
      *  If you encounter an error while attempting to wrap the property in question,
      *  you can choose to throw. This will cause a WrapError.WrappingFailedForObject
-     *  to be thrown from the main `Wrap()` call that started the process.
+     *  to be thrown from the main `wrap()` call that started the process.
      */
     func wrap(propertyNamed propertyName: String, originalValue: Any) throws -> Any?
 }
@@ -170,7 +170,7 @@ public protocol WrappableDate {
  *  Class used to wrap an object or value. Use this in any custom `wrap()` implementations
  *  in case you only want to add on top of the default implementation.
  *
- *  You normally don't have to interact with this API. Use the `Wrap()` function instead
+ *  You normally don't have to interact with this API. Use the `wrap()` function instead
  *  to wrap an object from top-level code.
  */
 public class Wrapper {

--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -69,8 +69,8 @@ public typealias WrappedDictionary = [String : AnyObject]
  *
  *  See also `WrappableKey` (for dictionary keys) and `WrappableEnum` for Enum values.
  */
-public func Wrap<T>(object: T, dateFormatter: NSDateFormatter? = nil) throws -> WrappedDictionary {
-    return try Wrapper(dateFormatter: dateFormatter).wrap(object, enableCustomizedWrapping: true)
+public func Wrap<T>(_ object: T, dateFormatter: NSDateFormatter? = nil) throws -> WrappedDictionary {
+    return try Wrapper(dateFormatter: dateFormatter).wrap(object: object, enableCustomizedWrapping: true)
 }
 
 /**
@@ -78,8 +78,8 @@ public func Wrap<T>(object: T, dateFormatter: NSDateFormatter? = nil) throws -> 
  *
  *  See the documentation for the dictionary-based `Wrap()` function for more information
  */
-public func Wrap<T>(object: T, writingOptions: NSJSONWritingOptions? = nil, dateFormatter: NSDateFormatter? = nil) throws -> NSData {
-    return try Wrapper(dateFormatter: dateFormatter).wrap(object, writingOptions: writingOptions ?? [])
+public func Wrap<T>(_ object: T, writingOptions: NSJSONWritingOptions? = nil, dateFormatter: NSDateFormatter? = nil) throws -> NSData {
+    return try Wrapper(dateFormatter: dateFormatter).wrap(object: object, writingOptions: writingOptions ?? [])
 }
 
 /**
@@ -87,7 +87,7 @@ public func Wrap<T>(object: T, writingOptions: NSJSONWritingOptions? = nil, date
  *
  *  See the documentation for the dictionary-based `Wrap()` function for more information
  */
-public func Wrap<T>(objects: [T], dateFormatter: NSDateFormatter? = nil) throws -> [WrappedDictionary] {
+public func Wrap<T>(_ objects: [T], dateFormatter: NSDateFormatter? = nil) throws -> [WrappedDictionary] {
     return try objects.map({ try Wrap($0) })
 }
 
@@ -98,7 +98,7 @@ public func Wrap<T>(objects: [T], dateFormatter: NSDateFormatter? = nil) throws 
  */
 public func Wrap<T>(objects: [T], writingOptions: NSJSONWritingOptions? = nil, dateFormatter: NSDateFormatter? = nil) throws -> NSData {
     let dictionaries: [WrappedDictionary] = try Wrap(objects)
-    return try NSJSONSerialization.dataWithJSONObject(dictionaries, options: writingOptions ?? [])
+    return try NSJSONSerialization.data(withJSONObject: dictionaries as AnyObject, options: writingOptions ?? [])
 }
 
 /**
@@ -126,7 +126,7 @@ public protocol WrapCustomizable {
      *
      *  Returning nil from this method will cause Wrap to skip the property
      */
-    func keyForWrappingPropertyNamed(propertyName: String) -> String?
+    func keyForWrapping(propertyName: String) -> String?
     /**
      *  Override the wrapping of any property of this type
      *
@@ -142,7 +142,7 @@ public protocol WrapCustomizable {
      *  you can choose to throw. This will cause a WrapError.WrappingFailedForObject
      *  to be thrown from the main `Wrap()` call that started the process.
      */
-    func wrapPropertyNamed(propertyName: String, withValue value: Any) throws -> AnyObject?
+    func wrap(propertyName: String, originalValue: Any) throws -> AnyObject?
 }
 
 /// Protocol implemented by types that may be used as keys in a wrapped Dictionary
@@ -183,12 +183,12 @@ public class Wrapper {
     
     /// Perform automatic wrapping of an object or value. For more information, see `Wrap()`.
     public func wrap(object: Any) throws -> WrappedDictionary {
-        return try self.wrap(object, enableCustomizedWrapping: false)
+        return try self.wrap(object: object, enableCustomizedWrapping: false)
     }
 }
 
 /// Error type used by Wrap
-public enum WrapError: ErrorType {
+public enum WrapError: ErrorProtocol {
     /// Thrown when an invalid top level object (such as a String or Int) was passed to `Wrap()`
     case InvalidTopLevelObject(Any)
     /// Thrown when an object couldn't be wrapped. This is a last resort error.
@@ -200,15 +200,15 @@ public enum WrapError: ErrorType {
 /// Extension containing default implementations of `WrapCustomizable`. Override as you see fit.
 public extension WrapCustomizable {
     func wrap() -> AnyObject? {
-        return (try? Wrapper().wrap(self) as WrappedDictionary)
+        return (try? Wrapper().wrap(object: self) as WrappedDictionary) as AnyObject?
     }
     
-    func keyForWrappingPropertyNamed(propertyName: String) -> String? {
+    func keyForWrapping(propertyName: String) -> String? {
         return propertyName
     }
     
-    func wrapPropertyNamed(propertyName: String, withValue value: Any) throws -> AnyObject? {
-        return try Wrapper().wrapValue(value, propertyName: propertyName)
+    func wrap(propertyName: String, originalValue: Any) throws -> AnyObject? {
+        return try Wrapper().wrap(value: originalValue, propertyName: propertyName)
     }
 }
 
@@ -222,21 +222,21 @@ public extension WrappableEnum where Self: RawRepresentable {
 /// Extension customizing how Arrays are wrapped
 extension Array: WrapCustomizable {
     public func wrap() -> AnyObject? {
-        return try? Wrapper().wrapCollection(self)
+        return try? Wrapper().wrap(collection: self) as AnyObject
     }
 }
 
 /// Extension customizing how Dictionaries are wrapped
 extension Dictionary: WrapCustomizable {
     public func wrap() -> AnyObject? {
-        return try? Wrapper().wrapDictionary(self)
+        return try? Wrapper().wrap(dictionary: self) as AnyObject
     }
 }
 
 /// Extension customizing how Sets are wrapped
 extension Set: WrapCustomizable {
     public func wrap() -> AnyObject? {
-        return try? Wrapper().wrapCollection(self)
+        return try? Wrapper().wrap(collection: self) as AnyObject
     }
 }
 
@@ -250,14 +250,21 @@ extension NSString: WrapCustomizable {
 /// Extension customizing how NSURLs are wrapped
 extension NSURL: WrapCustomizable {
     public func wrap() -> AnyObject? {
-        return self.absoluteString
+        return self.absoluteString as AnyObject
+    }
+}
+
+/// Extension customizing how NSArrays are wrapped
+extension NSArray: WrapCustomizable {
+    public func wrap() -> AnyObject? {
+        return try? Wrapper().wrap(collection: self as [Element]) as AnyObject
     }
 }
 
 /// Extension customizing how NSDictionaries are wrapped
 extension NSDictionary: WrapCustomizable {
     public func wrap() -> AnyObject? {
-        return try? Wrapper().wrapDictionary(self as [NSObject : AnyObject])
+        return try? Wrapper().wrap(dictionary: self as [NSObject : AnyObject]) as AnyObject
     }
 }
 
@@ -274,7 +281,7 @@ private extension Wrapper {
     func wrap<T>(object: T, enableCustomizedWrapping: Bool) throws -> WrappedDictionary {
         if enableCustomizedWrapping {
             if let customizable = object as? WrapCustomizable {
-                let wrapped = try self.performCustomWrappingForObject(customizable)
+                let wrapped = try self.performCustomWrapping(object: customizable)
                 
                 guard let wrappedDictionary = wrapped as? WrappedDictionary else {
                     throw WrapError.InvalidTopLevelObject(object)
@@ -289,26 +296,26 @@ private extension Wrapper {
         
         while let mirror = currentMirror {
             mirrors.append(mirror)
-            currentMirror = mirror.superclassMirror()
+            currentMirror = mirror.superclassMirror
         }
         
-        return try self.performWrappingForObject(object, usingMirrors: mirrors.reverse())
+        return try self.performWrapping(object: object, mirrors: mirrors.reversed())
     }
     
     func wrap<T>(object: T, writingOptions: NSJSONWritingOptions) throws -> NSData {
-        let dictionary = try self.wrap(object, enableCustomizedWrapping: true)
-        return try NSJSONSerialization.dataWithJSONObject(dictionary, options: writingOptions)
+        let dictionary = try self.wrap(object: object, enableCustomizedWrapping: true)
+        return try NSJSONSerialization.data(withJSONObject: dictionary as AnyObject, options: writingOptions)
     }
     
-    func wrapValue<T>(value: T, propertyName: String? = nil) throws -> AnyObject {
+    func wrap<T>(value: T, propertyName: String? = nil) throws -> AnyObject {
         if let customizable = value as? WrapCustomizable {
-            return try self.performCustomWrappingForObject(customizable)
+            return try self.performCustomWrapping(object: customizable)
         }
         
         let mirror = Mirror(reflecting: value)
         
         if mirror.children.isEmpty {
-            if mirror.displayStyle == .Enum {
+            if mirror.displayStyle == .enum {
                 if let wrappableEnum = value as? WrappableEnum {
                     if let wrapped = wrappableEnum.wrap() {
                         return wrapped
@@ -317,36 +324,36 @@ private extension Wrapper {
                     throw WrapError.WrappingFailedForObject(value)
                 }
                 
-                return self.verifyWrappedValue("\(value)", propertyName: propertyName)
+                return self.verifyWrappedValue(value: "\(value)", propertyName: propertyName)
             } else if let date = value as? NSDate {
-                return self.wrapDate(date)
+                return self.wrap(date: date) as AnyObject
             }
             
-            return self.verifyWrappedValue(value, propertyName: propertyName)
+            return self.verifyWrappedValue(value: value, propertyName: propertyName)
         } else if value is NilLiteralConvertible && mirror.children.count == 1 {
-            if let firstMirrorChild = mirror.children.first where firstMirrorChild.label == "Some" {
-                return try self.wrapValue(firstMirrorChild.value, propertyName: propertyName)
+            if let firstMirrorChild = mirror.children.first {
+                return try self.wrap(value: firstMirrorChild.value, propertyName: propertyName)
             }
         }
         
-        let wrapped = try self.wrap(value, enableCustomizedWrapping: false)
+        let wrapped = try self.wrap(object: value, enableCustomizedWrapping: false)
         
-        return self.verifyWrappedValue(wrapped, propertyName: propertyName)
+        return self.verifyWrappedValue(value: wrapped, propertyName: propertyName)
     }
     
-    func wrapCollection<T: CollectionType>(collection: T) throws -> [AnyObject] {
+    func wrap<T: Collection>(collection: T) throws -> [AnyObject] {
         var wrappedArray = [AnyObject]()
         let wrapper = Wrapper()
         
         for element in collection {
-            let wrapped = try wrapper.wrapValue(element)
+            let wrapped = try wrapper.wrap(value: element)
             wrappedArray.append(wrapped)
         }
         
         return wrappedArray
     }
     
-    func wrapDictionary<K: Hashable, V>(dictionary: [K : V]) throws -> WrappedDictionary {
+    func wrap<K: Hashable, V>(dictionary: [K : V]) throws -> WrappedDictionary {
         var wrappedDictionary = WrappedDictionary()
         let wrapper = Wrapper()
         
@@ -364,14 +371,14 @@ private extension Wrapper {
             }
             
             if let wrappedKey = wrappedKey {
-                wrappedDictionary[wrappedKey] = try wrapper.wrapValue(value, propertyName: wrappedKey)
+                wrappedDictionary[wrappedKey] = try wrapper.wrap(value: value, propertyName: wrappedKey)
             }
         }
         
         return wrappedDictionary
     }
     
-    func wrapDate(date: NSDate) -> String {
+    func wrap(date: NSDate) -> String {
         let dateFormatter: NSDateFormatter
         
         if let existingFormatter = self.dateFormatter {
@@ -382,10 +389,10 @@ private extension Wrapper {
             self.dateFormatter = dateFormatter
         }
         
-        return dateFormatter.stringFromDate(date)
+        return dateFormatter.string(from: date)
     }
     
-    func performWrappingForObject<T>(object: T, usingMirrors mirrors: [Mirror]) throws -> WrappedDictionary {
+    func performWrapping<T>(object: T, mirrors: [Mirror]) throws -> WrappedDictionary {
         let customizable = object as? WrapCustomizable
         var wrappedDictionary = WrappedDictionary()
         
@@ -402,16 +409,16 @@ private extension Wrapper {
                 let wrappingKey: String?
                 
                 if let customizable = customizable {
-                    wrappingKey = customizable.keyForWrappingPropertyNamed(propertyName)
+                    wrappingKey = customizable.keyForWrapping(propertyName: propertyName)
                 } else {
                     wrappingKey = propertyName
                 }
                 
                 if let wrappingKey = wrappingKey {
-                    if let wrappedProperty = try customizable?.wrapPropertyNamed(propertyName, withValue: property.value) {
+                    if let wrappedProperty = try customizable?.wrap(propertyName: propertyName, originalValue: property.value) {
                         wrappedDictionary[wrappingKey] = wrappedProperty
                     } else {
-                        wrappedDictionary[wrappingKey] = try self.wrapValue(property.value, propertyName: propertyName)
+                        wrappedDictionary[wrappingKey] = try self.wrap(value: property.value, propertyName: propertyName)
                     }
                 }
             }
@@ -420,7 +427,7 @@ private extension Wrapper {
         return wrappedDictionary
     }
     
-    func performCustomWrappingForObject(object: WrapCustomizable) throws -> AnyObject {
+    func performCustomWrapping(object: WrapCustomizable) throws -> AnyObject {
         guard let wrapped = object.wrap() else {
             throw WrapError.WrappingFailedForObject(object)
         }
@@ -430,7 +437,7 @@ private extension Wrapper {
     
     func verifyWrappedValue(value: Any, propertyName: String?) -> AnyObject {
         guard let object = value as? AnyObject else {
-            return WrappedDictionary()
+            return WrappedDictionary() as AnyObject
         }
         
         return object

--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -126,7 +126,7 @@ public protocol WrapCustomizable {
      *
      *  Returning nil from this method will cause Wrap to skip the property
      */
-    func keyForWrapping(propertyName: String) -> String?
+    func keyForWrapping(propertyNamed propertyName: String) -> String?
     /**
      *  Override the wrapping of any property of this type
      *
@@ -142,7 +142,7 @@ public protocol WrapCustomizable {
      *  you can choose to throw. This will cause a WrapError.WrappingFailedForObject
      *  to be thrown from the main `Wrap()` call that started the process.
      */
-    func wrap(propertyName: String, originalValue: Any) throws -> Any?
+    func wrap(propertyNamed propertyName: String, originalValue: Any) throws -> Any?
 }
 
 /// Protocol implemented by types that may be used as keys in a wrapped Dictionary
@@ -209,11 +209,11 @@ public extension WrapCustomizable {
         return try? Wrapper().wrap(object: self)
     }
     
-    func keyForWrapping(propertyName: String) -> String? {
+    func keyForWrapping(propertyNamed propertyName: String) -> String? {
         return propertyName
     }
     
-    func wrap(propertyName: String, originalValue: Any) throws -> Any? {
+    func wrap(propertyNamed propertyName: String, originalValue: Any) throws -> Any? {
         return try Wrapper().wrap(value: originalValue, propertyName: propertyName)
     }
 }
@@ -431,13 +431,13 @@ private extension Wrapper {
                 let wrappingKey: String?
                 
                 if let customizable = customizable {
-                    wrappingKey = customizable.keyForWrapping(propertyName: propertyName)
+                    wrappingKey = customizable.keyForWrapping(propertyNamed: propertyName)
                 } else {
                     wrappingKey = propertyName
                 }
                 
                 if let wrappingKey = wrappingKey {
-                    if let wrappedProperty = try customizable?.wrap(propertyName: propertyName, originalValue: property.value) {
+                    if let wrappedProperty = try customizable?.wrap(propertyNamed: propertyName, originalValue: property.value) {
                         wrappedDictionary[wrappingKey] = wrappedProperty
                     } else {
                         wrappedDictionary[wrappingKey] = try self.wrap(value: property.value, propertyName: propertyName)

--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -118,7 +118,7 @@ public protocol WrapCustomizable {
      *  cause an infinite recursion.
      *
      *  Returning nil from this method will be treated as an error, and cause
-     *  a `WrapError.WrappingFailedForObject()` error to be thrown.
+     *  a `WrapError.wrappingFailedForObject()` error to be thrown.
      */
     func wrap() -> Any?
     /**

--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -194,7 +194,7 @@ public class Wrapper {
 }
 
 /// Error type used by Wrap
-public enum WrapError: ErrorProtocol {
+public enum WrapError: Error {
     /// Thrown when an invalid top level object (such as a String or Int) was passed to `Wrap()`
     case InvalidTopLevelObject(Any)
     /// Thrown when an object couldn't be wrapped. This is a last resort error.
@@ -352,7 +352,7 @@ private extension Wrapper {
             }
             
             return self.verifyWrappedValue(value: value, propertyName: propertyName)
-        } else if value is NilLiteralConvertible && mirror.children.count == 1 {
+        } else if value is ExpressibleByNilLiteral && mirror.children.count == 1 {
             if let firstMirrorChild = mirror.children.first {
                 return try self.wrap(value: firstMirrorChild.value, propertyName: propertyName)
             }

--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -246,6 +246,20 @@ extension Set: WrapCustomizable {
     }
 }
 
+/// Extension customizing how Int64s are wrapped, ensuring compatbility with 32 bit systems
+extension Int64: WrapCustomizable {
+    public func wrap() -> Any? {
+        return NSNumber(value: self)
+    }
+}
+
+/// Extension customizing how UInt64s are wrapped, ensuring compatbility with 32 bit systems
+extension UInt64: WrapCustomizable {
+    public func wrap() -> Any? {
+        return NSNumber(value: self)
+    }
+}
+
 /// Extension customizing how NSStrings are wrapped
 extension NSString: WrapCustomizable {
     public func wrap() -> Any? {

--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -96,7 +96,7 @@ public func Wrap<T>(_ objects: [T], dateFormatter: DateFormatter? = nil) throws 
  *
  *  See the documentation for the dictionary-based `Wrap()` function for more information
  */
-public func Wrap<T>(objects: [T], writingOptions: JSONSerialization.WritingOptions? = nil, dateFormatter: DateFormatter? = nil) throws -> Data {
+public func Wrap<T>(_ objects: [T], writingOptions: JSONSerialization.WritingOptions? = nil, dateFormatter: DateFormatter? = nil) throws -> Data {
     let dictionaries: [WrappedDictionary] = try Wrap(objects)
     return try JSONSerialization.data(withJSONObject: dictionaries as AnyObject, options: writingOptions ?? [])
 }

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -11,7 +11,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "string" : "A string",
                 "int" : 15,
                 "double" : 7.6
@@ -29,7 +29,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "string" : "A string",
                 "int" : 5
             ])
@@ -51,7 +51,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "constantString" : "A string",
                 "mutableInt" : 15,
                 "nested": [
@@ -71,9 +71,9 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Enum.First), againstDictionary: [:])
+            try Verify(dictionary: wrap(Enum.First), againstDictionary: [:])
             
-            try Verify(dictionary: Wrap(Enum.Second("Hello")), againstDictionary: [
+            try Verify(dictionary: wrap(Enum.Second("Hello")), againstDictionary: [
                 "Second" : "Hello"
             ])
         } catch {
@@ -109,7 +109,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "first" : "First",
                 "second" : [
                     "Second" : "Hello"
@@ -141,12 +141,12 @@ class WrapTests: XCTestCase {
         do {
             let model = Model(date: date, nsDate: nsDate)
             
-            try Verify(dictionary: Wrap(model, dateFormatter: dateFormatter), againstDictionary: [
+            try Verify(dictionary: wrap(model, dateFormatter: dateFormatter), againstDictionary: [
                 "date" : dateFormatter.string(from: date),
                 "nsDate" : dateFormatter.string(from: nsDate as Date)
             ])
         } catch {
-            XCTFail("\(try! Wrap(Model(date: date, nsDate: nsDate), dateFormatter: dateFormatter) as WrappedDictionary)")
+            XCTFail("\(try! wrap(Model(date: date, nsDate: nsDate), dateFormatter: dateFormatter) as WrappedDictionary)")
             XCTFail(error.toString())
         }
     }
@@ -155,7 +155,7 @@ class WrapTests: XCTestCase {
         struct Empty {}
         
         do {
-            try Verify(dictionary: Wrap(Empty()), againstDictionary: [:])
+            try Verify(dictionary: wrap(Empty()), againstDictionary: [:])
         } catch {
             XCTFail(error.toString())
         }
@@ -174,7 +174,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "empty" : [:],
                 "emptyWithOptional" : [:]
             ])
@@ -190,7 +190,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "homogeneous" : ["Wrap", "Tests"],
                 "mixed" : ["Wrap", 15, 8.3]
             ])
@@ -218,7 +218,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "homogeneous" : [
                     "Key1" : "Value1",
                     "Key2" : "Value2"
@@ -245,7 +245,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "homogeneous" : ["Wrap", "Tests"],
                 "mixed" : ["Wrap", 15, 8.3]
             ])
@@ -261,7 +261,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "optionalURL" : "http://github.com",
                 "URL" : "http://google.com"
             ])
@@ -282,7 +282,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Subclass()), againstDictionary: [
+            try Verify(dictionary: wrap(Subclass()), againstDictionary: [
                 "string1" : "String1",
                 "string2" : "String2",
                 "int1" : 1,
@@ -300,7 +300,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "string" : "String",
                 "double" : 7.14
             ])
@@ -320,7 +320,7 @@ class WrapTests: XCTestCase {
         ]
         
         do {
-            try Verify(dictionary: Wrap(dictionary), againstDictionary: [
+            try Verify(dictionary: wrap(dictionary), againstDictionary: [
                 "model1" : [
                     "string" : "First"
                 ],
@@ -343,7 +343,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "nested" : [
                     "string" : "Nested model"
                 ]
@@ -370,7 +370,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            let wrapped: WrappedDictionary = try Wrap(Model())
+            let wrapped: WrappedDictionary = try wrap(Model())
             
             if let nested = wrapped["nested"] as? [WrappedDictionary] {
                 XCTAssertEqual(nested.count, 2)
@@ -406,7 +406,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "nested" : [
                     "model" : [
                         "string" : "Hello"
@@ -433,7 +433,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "superclass" : [
                     "string1" : "String1"
                 ],
@@ -463,7 +463,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            let wrappedDictionary :WrappedDictionary = try Wrap(FirstModel())
+            let wrappedDictionary :WrappedDictionary = try wrap(FirstModel())
             try Verify(dictionary: wrappedDictionary, againstDictionary: [
                 "string" : "First String",
                 "nestedDictionary" : [
@@ -488,7 +488,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "string" : "Hello",
                 "number" : 17,
                 "array" : ["Unwrap"]
@@ -516,7 +516,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "dictionary" : [
                     "15" : "First value",
                     "19" : "Second value"
@@ -547,7 +547,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "string" : "Default",
                 "totallyCustomized" : "I'm customized"
             ])
@@ -568,7 +568,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "custom" : "A value"
             ])
         } catch {
@@ -592,7 +592,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "int" : 27,
                 "custom" : "A value"
             ])
@@ -617,7 +617,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: wrap(Model()), againstDictionary: [
                 "string" : "Hello",
                 "int" : 27
             ])
@@ -634,7 +634,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            _ = try Wrap(Model()) as WrappedDictionary
+            _ = try wrap(Model()) as WrappedDictionary
             XCTFail("Should have thrown")
         } catch WrapError.wrappingFailedForObject(let object) {
             XCTAssertTrue(object is Model)
@@ -653,7 +653,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            _ = try Wrap(Model()) as WrappedDictionary
+            _ = try wrap(Model()) as WrappedDictionary
             XCTFail("Should have thrown")
         } catch WrapError.wrappingFailedForObject(let object) {
             XCTAssertTrue(object is Model)
@@ -664,7 +664,7 @@ class WrapTests: XCTestCase {
     
     func testInvalidRootObjectThrows() {
         do {
-            _ = try Wrap("A string") as WrappedDictionary
+            _ = try wrap("A string") as WrappedDictionary
         } catch WrapError.invalidTopLevelObject(let object) {
             XCTAssertEqual((object as? String) ?? "", "A string")
         } catch {
@@ -680,7 +680,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            let data: Data = try Wrap(Model())
+            let data: Data = try wrap(Model())
             let object = try JSONSerialization.jsonObject(with: data, options: [])
             
             guard let dictionary = object as? WrappedDictionary else {
@@ -704,7 +704,7 @@ class WrapTests: XCTestCase {
         
         do {
             let models = [Model(string: "A"), Model(string: "B"), Model(string: "C")]
-            let wrapped: [WrappedDictionary] = try Wrap(models)
+            let wrapped: [WrappedDictionary] = try wrap(models)
             XCTAssertEqual(wrapped.count, 3)
             
             try Verify(dictionary: wrapped[0], againstDictionary: ["string" : "A"])

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -270,6 +270,24 @@ class WrapTests: XCTestCase {
         }
     }
     
+    func test64BitIntegerProperties() {
+        struct Model {
+            let int = Int64.max
+            let uint = UInt64.max
+        }
+        
+        do {
+            let dictionary = try JSONSerialization.jsonObject(with: wrap(Model()), options: []) as! WrappedDictionary
+            
+            try verify(dictionary: dictionary, againstDictionary: [
+                "int" : Int64.max,
+                "uint" : UInt64.max
+            ])
+        } catch {
+            XCTFail(error.toString())
+        }
+    }
+    
     func testRootSubclass() {
         class Superclass {
             let string1 = "String1"
@@ -744,6 +762,26 @@ extension Int: Verifiable {
         }
         
         return Int(number)
+    }
+}
+
+extension Int64: Verifiable {
+    fileprivate static func convert(objectiveCObject object: NSObject) -> Int64? {
+        guard let number = object as? NSNumber else {
+            return nil
+        }
+        
+        return number.int64Value
+    }
+}
+
+extension UInt64: Verifiable {
+    fileprivate static func convert(objectiveCObject object: NSObject) -> UInt64? {
+        guard let number = object as? NSNumber else {
+            return nil
+        }
+        
+        return number.uint64Value
     }
 }
 

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -375,7 +375,7 @@ class WrapTests: XCTestCase {
             if let nested = wrapped["nested"] as? [WrappedDictionary] {
                 XCTAssertEqual(nested.count, 2)
                 
-                if let firstDictionary = nested.first, secondDictionary = nested.last {
+                if let firstDictionary = nested.first, let secondDictionary = nested.last {
                     try Verify(dictionary: firstDictionary, againstDictionary: [
                         "string1" : "String1"
                     ])

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -895,7 +895,7 @@ private func verify(array: [Any], againstArray expectedArray: [Any]) throws {
     }
 }
 
-private func verify(value: Any, againstValue expectedValue: Any) throws {
+private func verify(value: Any, againstValue expectedValue: Any, convertToObjectiveCObjectIfNeeded: Bool = true) throws {
     guard let expectedVerifiableValue = expectedValue as? Verifiable else {
         throw VerificationError.cannotVerifyValue(expectedValue)
     }
@@ -905,14 +905,16 @@ private func verify(value: Any, againstValue expectedValue: Any) throws {
     }
     
     if actualVerifiableValue.hashValue != expectedVerifiableValue.hashValue {
-        if let objectiveCObject = value as? NSObject {
-            let expectedValueType = type(of: expectedVerifiableValue)
-            
-            guard let convertedObject = expectedValueType.convert(objectiveCObject: objectiveCObject) else {
-                throw VerificationError.cannotVerifyValue(value)
+        if convertToObjectiveCObjectIfNeeded {
+            if let objectiveCObject = value as? NSObject {
+                let expectedValueType = type(of: expectedVerifiableValue)
+                
+                guard let convertedObject = expectedValueType.convert(objectiveCObject: objectiveCObject) else {
+                    throw VerificationError.cannotVerifyValue(value)
+                }
+                
+                return try verify(value: convertedObject, againstValue: expectedVerifiableValue, convertToObjectiveCObjectIfNeeded: false)
             }
-            
-            return try verify(value: convertedObject, againstValue: expectedVerifiableValue)
         }
         
         throw VerificationError.valueMismatchBetween(value, expectedValue)

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -636,7 +636,7 @@ class WrapTests: XCTestCase {
         do {
             _ = try Wrap(Model()) as WrappedDictionary
             XCTFail("Should have thrown")
-        } catch WrapError.WrappingFailedForObject(let object) {
+        } catch WrapError.wrappingFailedForObject(let object) {
             XCTAssertTrue(object is Model)
         } catch {
             XCTFail("Invalid error type: " + error.toString())
@@ -655,7 +655,7 @@ class WrapTests: XCTestCase {
         do {
             _ = try Wrap(Model()) as WrappedDictionary
             XCTFail("Should have thrown")
-        } catch WrapError.WrappingFailedForObject(let object) {
+        } catch WrapError.wrappingFailedForObject(let object) {
             XCTAssertTrue(object is Model)
         } catch {
             XCTFail("Invalid error type: " + error.toString())
@@ -665,7 +665,7 @@ class WrapTests: XCTestCase {
     func testInvalidRootObjectThrows() {
         do {
             _ = try Wrap("A string") as WrappedDictionary
-        } catch WrapError.InvalidTopLevelObject(let object) {
+        } catch WrapError.invalidTopLevelObject(let object) {
             XCTAssertEqual((object as? String) ?? "", "A string")
         } catch {
             XCTFail("Invalid error type: " + error.toString())

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -692,7 +692,7 @@ private protocol MockProtocol {
 
 // MARK: - Utilities
 
-private enum DictionaryVerificationError: ErrorProtocol {
+private enum DictionaryVerificationError: Error {
     case CountMismatch
     case CannotVerifyValue(AnyObject)
     case MissingValueForKey(String)
@@ -759,7 +759,7 @@ private func Verify(value: AnyObject, againstValue expectedValue: AnyObject) thr
     }
 }
 
-private extension ErrorProtocol {
+private extension Error {
     func toString() -> String {
         if let stringConvertible = self as? CustomStringConvertible {
             return stringConvertible.description

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -11,7 +11,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "string" : "A string",
                 "int" : 15,
                 "double" : 7.6
@@ -29,7 +29,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "string" : "A string",
                 "int" : 5
             ])
@@ -51,7 +51,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "constantString" : "A string",
                 "mutableInt" : 15,
                 "nested": [
@@ -71,9 +71,9 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Enum.First), againstDictionary: [:])
+            try Verify(dictionary: Wrap(Enum.First), againstDictionary: [:])
             
-            try VerifyDictionary(Wrap(Enum.Second("Hello")), againstDictionary: [
+            try Verify(dictionary: Wrap(Enum.Second("Hello")), againstDictionary: [
                 "Second" : "Hello"
             ])
         } catch {
@@ -109,7 +109,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "first" : "First",
                 "second" : [
                     "Second" : "Hello"
@@ -139,8 +139,8 @@ class WrapTests: XCTestCase {
         do {
             let model = Model(date: date)
             
-            try VerifyDictionary(Wrap(model, dateFormatter: dateFormatter), againstDictionary: [
-                "date" : dateFormatter.stringFromDate(date)
+            try Verify(dictionary: Wrap(model, dateFormatter: dateFormatter), againstDictionary: [
+                "date" : dateFormatter.string(from: date) as AnyObject
             ])
         } catch {
             XCTFail(error.toString())
@@ -151,7 +151,7 @@ class WrapTests: XCTestCase {
         struct Empty {}
         
         do {
-            try VerifyDictionary(Wrap(Empty()), againstDictionary: [:])
+            try Verify(dictionary: Wrap(Empty()), againstDictionary: [:])
         } catch {
             XCTFail(error.toString())
         }
@@ -170,7 +170,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "empty" : [:],
                 "emptyWithOptional" : [:]
             ])
@@ -186,7 +186,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "homogeneous" : ["Wrap", "Tests"],
                 "mixed" : ["Wrap", 15, 8.3]
             ])
@@ -214,7 +214,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "homogeneous" : [
                     "Key1" : "Value1",
                     "Key2" : "Value2"
@@ -241,7 +241,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "homogeneous" : ["Wrap", "Tests"],
                 "mixed" : ["Wrap", 15, 8.3]
             ])
@@ -257,7 +257,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "optionalURL" : "http://github.com",
                 "URL" : "http://google.com"
             ])
@@ -278,7 +278,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Subclass()), againstDictionary: [
+            try Verify(dictionary: Wrap(Subclass()), againstDictionary: [
                 "string1" : "String1",
                 "string2" : "String2",
                 "int1" : 1,
@@ -296,7 +296,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "string" : "String",
                 "double" : 7.14
             ])
@@ -316,7 +316,7 @@ class WrapTests: XCTestCase {
         ]
         
         do {
-            try VerifyDictionary(Wrap(dictionary), againstDictionary: [
+            try Verify(dictionary: Wrap(dictionary), againstDictionary: [
                 "model1" : [
                     "string" : "First"
                 ],
@@ -339,7 +339,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "nested" : [
                     "string" : "Nested model"
                 ]
@@ -372,11 +372,11 @@ class WrapTests: XCTestCase {
                 XCTAssertEqual(nested.count, 2)
                 
                 if let firstDictionary = nested.first, secondDictionary = nested.last {
-                    try VerifyDictionary(firstDictionary, againstDictionary: [
+                    try Verify(dictionary: firstDictionary, againstDictionary: [
                         "string1" : "String1"
                     ])
                     
-                    try VerifyDictionary(secondDictionary, againstDictionary: [
+                    try Verify(dictionary: secondDictionary, againstDictionary: [
                         "string2" : "String2"
                     ])
                 } else {
@@ -402,7 +402,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "nested" : [
                     "model" : [
                         "string" : "Hello"
@@ -429,7 +429,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "superclass" : [
                     "string1" : "String1"
                 ],
@@ -446,12 +446,12 @@ class WrapTests: XCTestCase {
     func testObjectiveCObjectProperties() {
         struct Model {
             let string = NSString(string: "Hello")
-            let number = NSNumber(integer: 17)
+            let number = NSNumber(value: 17)
             let array = NSArray(object: NSString(string: "Unwrap"))
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "string" : "Hello",
                 "number" : 17,
                 "array" : ["Unwrap"]
@@ -479,7 +479,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "dictionary" : [
                     "15" : "First value",
                     "19" : "Second value"
@@ -496,7 +496,7 @@ class WrapTests: XCTestCase {
             let customized = "I'm customized"
             let skipThis = 15
             
-            private func keyForWrappingPropertyNamed(propertyName: String) -> String? {
+            private func keyForWrapping(propertyName: String) -> String? {
                 if propertyName == "customized" {
                     return "totallyCustomized"
                 }
@@ -510,7 +510,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "string" : "Default",
                 "totallyCustomized" : "I'm customized"
             ])
@@ -531,7 +531,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "custom" : "A value"
             ])
         } catch {
@@ -545,9 +545,9 @@ class WrapTests: XCTestCase {
             
             func wrap() -> AnyObject? {
                 do {
-                    var wrapped = try Wrapper().wrap(self)
+                    var wrapped = try Wrapper().wrap(object: self)
                     wrapped["custom"] = "A value"
-                    return wrapped
+                    return wrapped as AnyObject
                 } catch {
                     return nil
                 }
@@ -555,7 +555,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "int" : 27,
                 "custom" : "A value"
             ])
@@ -569,9 +569,9 @@ class WrapTests: XCTestCase {
             let string = "Hello"
             let int = 16
             
-            private func wrapPropertyNamed(propertyName: String, withValue value: Any) -> AnyObject? {
+            func wrap(propertyName: String, originalValue: Any) throws -> AnyObject? {
                 if propertyName == "int" {
-                    XCTAssertEqual((value as? Int) ?? 0, self.int)
+                    XCTAssertEqual((originalValue as? Int) ?? 0, self.int)
                     return 27
                 }
                 
@@ -580,7 +580,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try VerifyDictionary(Wrap(Model()), againstDictionary: [
+            try Verify(dictionary: Wrap(Model()), againstDictionary: [
                 "string" : "Hello",
                 "int" : 27
             ])
@@ -610,7 +610,7 @@ class WrapTests: XCTestCase {
         struct Model: WrapCustomizable {
             let string = "A string"
             
-            private func wrapPropertyNamed(propertyName: String, withValue value: Any) throws -> AnyObject? {
+            func wrap(propertyName: String, originalValue: Any) throws -> AnyObject? {
                 throw NSError(domain: "ERROR", code: 0, userInfo: nil)
             }
         }
@@ -644,13 +644,13 @@ class WrapTests: XCTestCase {
         
         do {
             let data: NSData = try Wrap(Model())
-            let object = try NSJSONSerialization.JSONObjectWithData(data, options: [])
+            let object = try NSJSONSerialization.jsonObject(with: data, options: [])
             
             guard let dictionary = object as? WrappedDictionary else {
                 return XCTFail("Invalid encoded type")
             }
             
-            try VerifyDictionary(dictionary, againstDictionary: [
+            try Verify(dictionary: dictionary, againstDictionary: [
                 "string" : "A string",
                 "int" : 42,
                 "array" : [4, 1, 9]
@@ -670,9 +670,9 @@ class WrapTests: XCTestCase {
             let wrapped: [WrappedDictionary] = try Wrap(models)
             XCTAssertEqual(wrapped.count, 3)
             
-            try VerifyDictionary(wrapped[0], againstDictionary: ["string" : "A"])
-            try VerifyDictionary(wrapped[1], againstDictionary: ["string" : "B"])
-            try VerifyDictionary(wrapped[2], againstDictionary: ["string" : "C"])
+            try Verify(dictionary: wrapped[0], againstDictionary: ["string" : "A"])
+            try Verify(dictionary: wrapped[1], againstDictionary: ["string" : "B"])
+            try Verify(dictionary: wrapped[2], againstDictionary: ["string" : "C"])
         } catch {
             XCTFail(error.toString())
         }
@@ -688,7 +688,7 @@ private protocol MockProtocol {
 
 // MARK: - Utilities
 
-private enum DictionaryVerificationError: ErrorType {
+private enum DictionaryVerificationError: ErrorProtocol {
     case CountMismatch
     case CannotVerifyValue(AnyObject)
     case MissingValueForKey(String)
@@ -702,7 +702,7 @@ private protocol Verifiable {
 extension NSNumber: Verifiable {}
 extension NSString: Verifiable {}
 
-private func VerifyDictionary(dictionary: WrappedDictionary, againstDictionary expectedDictionary: WrappedDictionary) throws {
+private func Verify(dictionary: WrappedDictionary, againstDictionary expectedDictionary: WrappedDictionary) throws {
     if dictionary.count != expectedDictionary.count {
         throw DictionaryVerificationError.CountMismatch
     }
@@ -714,7 +714,7 @@ private func VerifyDictionary(dictionary: WrappedDictionary, againstDictionary e
         
         if let expectedNestedDictionary = expectedValue as? WrappedDictionary {
             if let actualNestedDictionary = actualValue as? WrappedDictionary {
-                try VerifyDictionary(actualNestedDictionary, againstDictionary: expectedNestedDictionary)
+                try Verify(dictionary: actualNestedDictionary, againstDictionary: expectedNestedDictionary)
                 continue
             } else {
                 throw DictionaryVerificationError.ValueMismatchBetween(actualValue, expectedValue)
@@ -727,8 +727,8 @@ private func VerifyDictionary(dictionary: WrappedDictionary, againstDictionary e
                     throw DictionaryVerificationError.CountMismatch
                 }
                 
-                for (index, value) in actualNestedArray.enumerate() {
-                    try VerifyValue(value, againstValue: expectedNestedArray[index])
+                for (index, value) in actualNestedArray.enumerated() {
+                    try Verify(value: value, againstValue: expectedNestedArray[index])
                 }
                 
                 continue
@@ -737,11 +737,11 @@ private func VerifyDictionary(dictionary: WrappedDictionary, againstDictionary e
             }
         }
         
-        try VerifyValue(actualValue, againstValue: expectedValue)
+        try Verify(value: actualValue, againstValue: expectedValue)
     }
 }
 
-private func VerifyValue(value: AnyObject, againstValue expectedValue: AnyObject) throws {
+private func Verify(value: AnyObject, againstValue expectedValue: AnyObject) throws {
     guard let expectedVerifiableValue = expectedValue as? Verifiable else {
         throw DictionaryVerificationError.CannotVerifyValue(expectedValue)
     }
@@ -755,7 +755,7 @@ private func VerifyValue(value: AnyObject, againstValue expectedValue: AnyObject
     }
 }
 
-private extension ErrorType {
+private extension ErrorProtocol {
     func toString() -> String {
         if let stringConvertible = self as? CustomStringConvertible {
             return stringConvertible.description

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -151,6 +151,26 @@ class WrapTests: XCTestCase {
         }
     }
     
+    func testDatePropertyWithCustomizableStruct() {
+        let date = Date()
+        
+        struct Model: WrapCustomizable {
+            let date: Date
+        }
+        
+        let dateFormatter = DateFormatter()
+        
+        do {
+            let model = Model(date: date)
+            
+            try verify(dictionary: wrap(model, dateFormatter: dateFormatter), againstDictionary: [
+                "date" : dateFormatter.string(from: date)
+            ])
+        } catch {
+            XCTFail(error.toString())
+        }
+    }
+    
     func testEmptyStruct() {
         struct Empty {}
         
@@ -578,7 +598,7 @@ class WrapTests: XCTestCase {
         struct Model: WrapCustomizable {
             let string = "A string"
             
-            func wrap() -> Any? {
+            func wrap(dateFormatter: DateFormatter?) -> Any? {
                 return [
                     "custom" : "A value"
                 ]
@@ -598,7 +618,7 @@ class WrapTests: XCTestCase {
         struct Model: WrapCustomizable {
             let int = 27
             
-            func wrap() -> Any? {
+            func wrap(dateFormatter: DateFormatter?) -> Any? {
                 do {
                     var wrapped = try Wrapper().wrap(object: self)
                     wrapped["custom"] = "A value"
@@ -624,7 +644,7 @@ class WrapTests: XCTestCase {
             let string = "Hello"
             let int = 16
             
-            func wrap(propertyNamed propertyName: String, originalValue: Any) throws -> Any? {
+            func wrap(propertyNamed propertyName: String, originalValue: Any, dateFormatter: DateFormatter?) throws -> Any? {
                 if propertyName == "int" {
                     XCTAssertEqual((originalValue as? Int) ?? 0, self.int)
                     return 27
@@ -646,7 +666,7 @@ class WrapTests: XCTestCase {
     
     func testCustomWrappingFailureThrows() {
         struct Model: WrapCustomizable {
-            func wrap() -> Any? {
+            func wrap(dateFormatter: DateFormatter?) -> Any? {
                 return nil
             }
         }
@@ -665,7 +685,7 @@ class WrapTests: XCTestCase {
         struct Model: WrapCustomizable {
             let string = "A string"
             
-            func wrap(propertyNamed propertyName: String, originalValue: Any) throws -> Any? {
+            func wrap(propertyNamed propertyName: String, originalValue: Any, dateFormatter: DateFormatter?) throws -> Any? {
                 throw NSError(domain: "ERROR", code: 0, userInfo: nil)
             }
         }

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -500,7 +500,7 @@ class WrapTests: XCTestCase {
             let customized = "I'm customized"
             let skipThis = 15
             
-            fileprivate func keyForWrapping(propertyName: String) -> String? {
+            fileprivate func keyForWrapping(propertyNamed propertyName: String) -> String? {
                 if propertyName == "customized" {
                     return "totallyCustomized"
                 }
@@ -573,7 +573,7 @@ class WrapTests: XCTestCase {
             let string = "Hello"
             let int = 16
             
-            func wrap(propertyName: String, originalValue: Any) throws -> Any? {
+            func wrap(propertyNamed propertyName: String, originalValue: Any) throws -> Any? {
                 if propertyName == "int" {
                     XCTAssertEqual((originalValue as? Int) ?? 0, self.int)
                     return 27
@@ -614,7 +614,7 @@ class WrapTests: XCTestCase {
         struct Model: WrapCustomizable {
             let string = "A string"
             
-            func wrap(propertyName: String, originalValue: Any) throws -> Any? {
+            func wrap(propertyNamed propertyName: String, originalValue: Any) throws -> Any? {
                 throw NSError(domain: "ERROR", code: 0, userInfo: nil)
             }
         }

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -128,21 +128,25 @@ class WrapTests: XCTestCase {
     }
     
     func testDateProperty() {
-        let date = NSDate()
+        let date = Date()
+        let nsDate = NSDate()
         
         struct Model {
-            let date: NSDate
+            let date: Date
+            let nsDate: NSDate
         }
         
-        let dateFormatter = NSDateFormatter()
+        let dateFormatter = DateFormatter()
         
         do {
-            let model = Model(date: date)
+            let model = Model(date: date, nsDate: nsDate)
             
             try Verify(dictionary: Wrap(model, dateFormatter: dateFormatter), againstDictionary: [
-                "date" : dateFormatter.string(from: date) as AnyObject
+                "date" : dateFormatter.string(from: date),
+                "nsDate" : dateFormatter.string(from: nsDate as Date)
             ])
         } catch {
+            XCTFail("\(try! Wrap(Model(date: date, nsDate: nsDate), dateFormatter: dateFormatter) as WrappedDictionary)")
             XCTFail(error.toString())
         }
     }
@@ -597,7 +601,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Wrap(Model()) as WrappedDictionary
+            _ = try Wrap(Model()) as WrappedDictionary
             XCTFail("Should have thrown")
         } catch WrapError.WrappingFailedForObject(let object) {
             XCTAssertTrue(object is Model)
@@ -616,7 +620,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Wrap(Model()) as WrappedDictionary
+            _ = try Wrap(Model()) as WrappedDictionary
             XCTFail("Should have thrown")
         } catch WrapError.WrappingFailedForObject(let object) {
             XCTAssertTrue(object is Model)
@@ -627,7 +631,7 @@ class WrapTests: XCTestCase {
     
     func testInvalidRootObjectThrows() {
         do {
-            try Wrap("A string") as WrappedDictionary
+            _ = try Wrap("A string") as WrappedDictionary
         } catch WrapError.InvalidTopLevelObject(let object) {
             XCTAssertEqual((object as? String) ?? "", "A string")
         } catch {
@@ -643,8 +647,8 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            let data: NSData = try Wrap(Model())
-            let object = try NSJSONSerialization.jsonObject(with: data, options: [])
+            let data: Data = try Wrap(Model())
+            let object = try JSONSerialization.jsonObject(with: data, options: [])
             
             guard let dictionary = object as? WrappedDictionary else {
                 return XCTFail("Invalid encoded type")

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -11,7 +11,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "string" : "A string",
                 "int" : 15,
                 "double" : 7.6
@@ -29,7 +29,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "string" : "A string",
                 "int" : 5
             ])
@@ -51,7 +51,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "constantString" : "A string",
                 "mutableInt" : 15,
                 "nested": [
@@ -71,9 +71,9 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Enum.first), againstDictionary: [:])
+            try verify(dictionary: wrap(Enum.first), againstDictionary: [:])
             
-            try Verify(dictionary: wrap(Enum.second("Hello")), againstDictionary: [
+            try verify(dictionary: wrap(Enum.second("Hello")), againstDictionary: [
                 "second" : "Hello"
             ])
         } catch {
@@ -109,7 +109,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "first" : "first",
                 "second" : [
                     "second" : "Hello"
@@ -141,7 +141,7 @@ class WrapTests: XCTestCase {
         do {
             let model = Model(date: date, nsDate: nsDate)
             
-            try Verify(dictionary: wrap(model, dateFormatter: dateFormatter), againstDictionary: [
+            try verify(dictionary: wrap(model, dateFormatter: dateFormatter), againstDictionary: [
                 "date" : dateFormatter.string(from: date),
                 "nsDate" : dateFormatter.string(from: nsDate as Date)
             ])
@@ -155,7 +155,7 @@ class WrapTests: XCTestCase {
         struct Empty {}
         
         do {
-            try Verify(dictionary: wrap(Empty()), againstDictionary: [:])
+            try verify(dictionary: wrap(Empty()), againstDictionary: [:])
         } catch {
             XCTFail(error.toString())
         }
@@ -174,7 +174,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "empty" : [:],
                 "emptyWithOptional" : [:]
             ])
@@ -190,7 +190,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "homogeneous" : ["Wrap", "Tests"],
                 "mixed" : ["Wrap", 15, 8.3]
             ])
@@ -218,7 +218,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "homogeneous" : [
                     "Key1" : "Value1",
                     "Key2" : "Value2"
@@ -245,7 +245,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "homogeneous" : ["Wrap", "Tests"],
                 "mixed" : ["Wrap", 15, 8.3]
             ])
@@ -261,7 +261,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "optionalURL" : "http://github.com",
                 "URL" : "http://google.com"
             ])
@@ -282,7 +282,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Subclass()), againstDictionary: [
+            try verify(dictionary: wrap(Subclass()), againstDictionary: [
                 "string1" : "String1",
                 "string2" : "String2",
                 "int1" : 1,
@@ -300,7 +300,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "string" : "String",
                 "double" : 7.14
             ])
@@ -320,7 +320,7 @@ class WrapTests: XCTestCase {
         ]
         
         do {
-            try Verify(dictionary: wrap(dictionary), againstDictionary: [
+            try verify(dictionary: wrap(dictionary), againstDictionary: [
                 "model1" : [
                     "string" : "First"
                 ],
@@ -343,7 +343,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "nested" : [
                     "string" : "Nested model"
                 ]
@@ -376,11 +376,11 @@ class WrapTests: XCTestCase {
                 XCTAssertEqual(nested.count, 2)
                 
                 if let firstDictionary = nested.first, let secondDictionary = nested.last {
-                    try Verify(dictionary: firstDictionary, againstDictionary: [
+                    try verify(dictionary: firstDictionary, againstDictionary: [
                         "string1" : "String1"
                     ])
                     
-                    try Verify(dictionary: secondDictionary, againstDictionary: [
+                    try verify(dictionary: secondDictionary, againstDictionary: [
                         "string2" : "String2"
                     ])
                 } else {
@@ -406,7 +406,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "nested" : [
                     "model" : [
                         "string" : "Hello"
@@ -433,7 +433,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "superclass" : [
                     "string1" : "String1"
                 ],
@@ -464,7 +464,7 @@ class WrapTests: XCTestCase {
         
         do {
             let wrappedDictionary :WrappedDictionary = try wrap(FirstModel())
-            try Verify(dictionary: wrappedDictionary, againstDictionary: [
+            try verify(dictionary: wrappedDictionary, againstDictionary: [
                 "string" : "First String",
                 "nestedDictionary" : [
                     "nestedDictionary" : [
@@ -488,7 +488,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "string" : "Hello",
                 "number" : 17,
                 "array" : ["Unwrap"]
@@ -516,7 +516,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "dictionary" : [
                     "15" : "First value",
                     "19" : "Second value"
@@ -547,7 +547,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "string" : "Default",
                 "totallyCustomized" : "I'm customized"
             ])
@@ -568,7 +568,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "custom" : "A value"
             ])
         } catch {
@@ -592,7 +592,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "int" : 27,
                 "custom" : "A value"
             ])
@@ -617,7 +617,7 @@ class WrapTests: XCTestCase {
         }
         
         do {
-            try Verify(dictionary: wrap(Model()), againstDictionary: [
+            try verify(dictionary: wrap(Model()), againstDictionary: [
                 "string" : "Hello",
                 "int" : 27
             ])
@@ -687,7 +687,7 @@ class WrapTests: XCTestCase {
                 return XCTFail("Invalid encoded type")
             }
             
-            try Verify(dictionary: dictionary, againstDictionary: [
+            try verify(dictionary: dictionary, againstDictionary: [
                 "string" : "A string",
                 "int" : 42,
                 "array" : [4, 1, 9]
@@ -707,9 +707,9 @@ class WrapTests: XCTestCase {
             let wrapped: [WrappedDictionary] = try wrap(models)
             XCTAssertEqual(wrapped.count, 3)
             
-            try Verify(dictionary: wrapped[0], againstDictionary: ["string" : "A"])
-            try Verify(dictionary: wrapped[1], againstDictionary: ["string" : "B"])
-            try Verify(dictionary: wrapped[2], againstDictionary: ["string" : "C"])
+            try verify(dictionary: wrapped[0], againstDictionary: ["string" : "A"])
+            try verify(dictionary: wrapped[1], againstDictionary: ["string" : "B"])
+            try verify(dictionary: wrapped[2], againstDictionary: ["string" : "C"])
         } catch {
             XCTFail(error.toString())
         }
@@ -795,7 +795,7 @@ extension NSDate: Verifiable {
     }
 }
 
-private func Verify(dictionary: WrappedDictionary, againstDictionary expectedDictionary: WrappedDictionary) throws {
+private func verify(dictionary: WrappedDictionary, againstDictionary expectedDictionary: WrappedDictionary) throws {
     if dictionary.count != expectedDictionary.count {
         throw VerificationError.countMismatch
     }
@@ -807,7 +807,7 @@ private func Verify(dictionary: WrappedDictionary, againstDictionary expectedDic
         
         if let expectedNestedDictionary = expectedValue as? WrappedDictionary {
             if let actualNestedDictionary = actualValue as? WrappedDictionary {
-                try Verify(dictionary: actualNestedDictionary, againstDictionary: expectedNestedDictionary)
+                try verify(dictionary: actualNestedDictionary, againstDictionary: expectedNestedDictionary)
                 continue
             } else {
                 throw VerificationError.valueMismatchBetween(actualValue, expectedValue)
@@ -816,18 +816,18 @@ private func Verify(dictionary: WrappedDictionary, againstDictionary expectedDic
         
         if let expectedNestedArray = expectedValue as? [Any] {
             if let actualNestedArray = actualValue as? [Any] {
-                try Verify(array: actualNestedArray, againstArray: expectedNestedArray)
+                try verify(array: actualNestedArray, againstArray: expectedNestedArray)
                 continue
             } else {
                 throw VerificationError.valueMismatchBetween(actualValue, expectedValue)
             }
         }
         
-        try Verify(value: actualValue, againstValue: expectedValue)
+        try verify(value: actualValue, againstValue: expectedValue)
     }
 }
 
-private func Verify(array: [Any], againstArray expectedArray: [Any]) throws {
+private func verify(array: [Any], againstArray expectedArray: [Any]) throws {
     if array.count != expectedArray.count {
         throw VerificationError.countMismatch
     }
@@ -837,7 +837,7 @@ private func Verify(array: [Any], againstArray expectedArray: [Any]) throws {
         
         if let expectedNestedDictionary = expectedValue as? WrappedDictionary {
             if let actualNestedDictionary = actualValue as? WrappedDictionary {
-                try Verify(dictionary: actualNestedDictionary, againstDictionary: expectedNestedDictionary)
+                try verify(dictionary: actualNestedDictionary, againstDictionary: expectedNestedDictionary)
                 continue
             } else {
                 throw VerificationError.valueMismatchBetween(actualValue, expectedValue)
@@ -846,18 +846,18 @@ private func Verify(array: [Any], againstArray expectedArray: [Any]) throws {
         
         if let expectedNestedArray = expectedValue as? [Any] {
             if let actualNestedArray = actualValue as? [Any] {
-                try Verify(array: actualNestedArray, againstArray: expectedNestedArray)
+                try verify(array: actualNestedArray, againstArray: expectedNestedArray)
                 continue
             } else {
                 throw VerificationError.valueMismatchBetween(actualValue, expectedValue)
             }
         }
         
-        try Verify(value: actualValue, againstValue: expectedValue)
+        try verify(value: actualValue, againstValue: expectedValue)
     }
 }
 
-private func Verify(value: Any, againstValue expectedValue: Any) throws {
+private func verify(value: Any, againstValue expectedValue: Any) throws {
     guard let expectedVerifiableValue = expectedValue as? Verifiable else {
         throw VerificationError.cannotVerifyValue(expectedValue)
     }
@@ -874,7 +874,7 @@ private func Verify(value: Any, againstValue expectedValue: Any) throws {
                 throw VerificationError.cannotVerifyValue(value)
             }
             
-            return try Verify(value: convertedObject, againstValue: expectedVerifiableValue)
+            return try verify(value: convertedObject, againstValue: expectedVerifiableValue)
         }
         
         throw VerificationError.valueMismatchBetween(value, expectedValue)

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -726,10 +726,10 @@ private protocol MockProtocol {
 // MARK: - Utilities
 
 private enum VerificationError: Error {
-    case CountMismatch
-    case CannotVerifyValue(Any)
-    case MissingValueForKey(String)
-    case ValueMismatchBetween(Any, Any)
+    case countMismatch
+    case cannotVerifyValue(Any)
+    case missingValueForKey(String)
+    case valueMismatchBetween(Any, Any)
 }
 
 private protocol Verifiable {
@@ -797,12 +797,12 @@ extension NSDate: Verifiable {
 
 private func Verify(dictionary: WrappedDictionary, againstDictionary expectedDictionary: WrappedDictionary) throws {
     if dictionary.count != expectedDictionary.count {
-        throw VerificationError.CountMismatch
+        throw VerificationError.countMismatch
     }
     
     for (key, expectedValue) in expectedDictionary {
         guard let actualValue = dictionary[key] else {
-            throw VerificationError.MissingValueForKey(key)
+            throw VerificationError.missingValueForKey(key)
         }
         
         if let expectedNestedDictionary = expectedValue as? WrappedDictionary {
@@ -810,7 +810,7 @@ private func Verify(dictionary: WrappedDictionary, againstDictionary expectedDic
                 try Verify(dictionary: actualNestedDictionary, againstDictionary: expectedNestedDictionary)
                 continue
             } else {
-                throw VerificationError.ValueMismatchBetween(actualValue, expectedValue)
+                throw VerificationError.valueMismatchBetween(actualValue, expectedValue)
             }
         }
         
@@ -819,7 +819,7 @@ private func Verify(dictionary: WrappedDictionary, againstDictionary expectedDic
                 try Verify(array: actualNestedArray, againstArray: expectedNestedArray)
                 continue
             } else {
-                throw VerificationError.ValueMismatchBetween(actualValue, expectedValue)
+                throw VerificationError.valueMismatchBetween(actualValue, expectedValue)
             }
         }
         
@@ -829,7 +829,7 @@ private func Verify(dictionary: WrappedDictionary, againstDictionary expectedDic
 
 private func Verify(array: [Any], againstArray expectedArray: [Any]) throws {
     if array.count != expectedArray.count {
-        throw VerificationError.CountMismatch
+        throw VerificationError.countMismatch
     }
     
     for (index, expectedValue) in expectedArray.enumerated() {
@@ -840,7 +840,7 @@ private func Verify(array: [Any], againstArray expectedArray: [Any]) throws {
                 try Verify(dictionary: actualNestedDictionary, againstDictionary: expectedNestedDictionary)
                 continue
             } else {
-                throw VerificationError.ValueMismatchBetween(actualValue, expectedValue)
+                throw VerificationError.valueMismatchBetween(actualValue, expectedValue)
             }
         }
         
@@ -849,7 +849,7 @@ private func Verify(array: [Any], againstArray expectedArray: [Any]) throws {
                 try Verify(array: actualNestedArray, againstArray: expectedNestedArray)
                 continue
             } else {
-                throw VerificationError.ValueMismatchBetween(actualValue, expectedValue)
+                throw VerificationError.valueMismatchBetween(actualValue, expectedValue)
             }
         }
         
@@ -859,11 +859,11 @@ private func Verify(array: [Any], againstArray expectedArray: [Any]) throws {
 
 private func Verify(value: Any, againstValue expectedValue: Any) throws {
     guard let expectedVerifiableValue = expectedValue as? Verifiable else {
-        throw VerificationError.CannotVerifyValue(expectedValue)
+        throw VerificationError.cannotVerifyValue(expectedValue)
     }
     
     guard let actualVerifiableValue = value as? Verifiable else {
-        throw VerificationError.CannotVerifyValue(value)
+        throw VerificationError.cannotVerifyValue(value)
     }
     
     if actualVerifiableValue.hashValue != expectedVerifiableValue.hashValue {
@@ -871,13 +871,13 @@ private func Verify(value: Any, againstValue expectedValue: Any) throws {
             let expectedValueType = type(of: expectedVerifiableValue)
             
             guard let convertedObject = expectedValueType.convert(objectiveCObject: objectiveCObject) else {
-                throw VerificationError.CannotVerifyValue(value)
+                throw VerificationError.cannotVerifyValue(value)
             }
             
             return try Verify(value: convertedObject, againstValue: expectedVerifiableValue)
         }
         
-        throw VerificationError.ValueMismatchBetween(value, expectedValue)
+        throw VerificationError.valueMismatchBetween(value, expectedValue)
     }
 }
 

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -752,6 +752,32 @@ class WrapTests: XCTestCase {
             XCTFail(error.toString())
         }
     }
+    
+    func testSnakeCasedKeyWrapping() {
+        struct Model: WrapCustomizable {
+            var wrapKeyStyle: WrapKeyStyle { return .convertToSnakeCase }
+            
+            let simple = "simple name"
+            let camelCased = "camel cased name"
+            let CAPITALIZED = "capitalized name"
+            let _underscored = "underscored name"
+            let center_underscored = "center underscored name"
+            let double__underscored = "double underscored name"
+        }
+        
+        do {
+            try verify(dictionary: wrap(Model()), againstDictionary: [
+                "simple" : "simple name",
+                "camel_cased" : "camel cased name",
+                "capitalized" : "capitalized name",
+                "_underscored" : "underscored name",
+                "center_underscored" : "center underscored name",
+                "double__underscored" : "double underscored name"
+            ])
+        } catch {
+            XCTFail(error.toString())
+        }
+    }
 }
 
 // MARK: - Mocks

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -66,15 +66,15 @@ class WrapTests: XCTestCase {
     
     func testRootEnum() {
         enum Enum {
-            case First
-            case Second(String)
+            case first
+            case second(String)
         }
         
         do {
-            try Verify(dictionary: wrap(Enum.First), againstDictionary: [:])
+            try Verify(dictionary: wrap(Enum.first), againstDictionary: [:])
             
-            try Verify(dictionary: wrap(Enum.Second("Hello")), againstDictionary: [
-                "Second" : "Hello"
+            try Verify(dictionary: wrap(Enum.second("Hello")), againstDictionary: [
+                "second" : "Hello"
             ])
         } catch {
             XCTFail(error.toString())
@@ -83,39 +83,39 @@ class WrapTests: XCTestCase {
     
     func testEnumProperties() {
         enum Enum {
-            case First
-            case Second(String)
-            case Third(intValue: Int)
+            case first
+            case second(String)
+            case third(intValue: Int)
         }
         
         enum IntEnum: Int, WrappableEnum {
-            case First
-            case Second = 17
+            case first
+            case second = 17
         }
         
         enum StringEnum: String, WrappableEnum {
-            case First = "First string"
-            case Second = "Second string"
+            case first = "First string"
+            case second = "Second string"
         }
         
         struct Model {
-            let first = Enum.First
-            let second = Enum.Second("Hello")
-            let third = Enum.Third(intValue: 15)
-            let firstInt = IntEnum.First
-            let secondInt = IntEnum.Second
-            let firstString = StringEnum.First
-            let secondString = StringEnum.Second
+            let first = Enum.first
+            let second = Enum.second("Hello")
+            let third = Enum.third(intValue: 15)
+            let firstInt = IntEnum.first
+            let secondInt = IntEnum.second
+            let firstString = StringEnum.first
+            let secondString = StringEnum.second
         }
         
         do {
             try Verify(dictionary: wrap(Model()), againstDictionary: [
-                "first" : "First",
+                "first" : "first",
                 "second" : [
-                    "Second" : "Hello"
+                    "second" : "Hello"
                 ],
                 "third" : [
-                    "Third" : 15
+                    "third" : 15
                 ],
                 "firstInt" : 0,
                 "secondInt" : 17,
@@ -500,8 +500,8 @@ class WrapTests: XCTestCase {
     
     func testWrappableKey() {
         enum Key: Int, WrappableKey {
-            case First = 15
-            case Second = 19
+            case first = 15
+            case second = 19
             
             func toWrappedKey() -> String {
                 return String(self.rawValue)
@@ -510,8 +510,8 @@ class WrapTests: XCTestCase {
         
         struct Model {
             let dictionary = [
-                Key.First : "First value",
-                Key.Second : "Second value"
+                Key.first : "First value",
+                Key.second : "Second value"
             ]
         }
         

--- a/Tests/WrapTests.swift
+++ b/Tests/WrapTests.swift
@@ -805,7 +805,6 @@ private func Verify(dictionary: WrappedDictionary, againstDictionary expectedDic
             throw VerificationError.missingValueForKey(key)
         }
         
-        try VerifyValue(actualValue, againstValue: expectedValue)
         if let expectedNestedDictionary = expectedValue as? WrappedDictionary {
             if let actualNestedDictionary = actualValue as? WrappedDictionary {
                 try Verify(dictionary: actualNestedDictionary, againstDictionary: expectedNestedDictionary)
@@ -815,8 +814,8 @@ private func Verify(dictionary: WrappedDictionary, againstDictionary expectedDic
             }
         }
         
-        if let expectedNestedArray = expectedValue as? [AnyObject] {
-            if let actualNestedArray = actualValue as? [AnyObject] {
+        if let expectedNestedArray = expectedValue as? [Any] {
+            if let actualNestedArray = actualValue as? [Any] {
                 try Verify(array: actualNestedArray, againstArray: expectedNestedArray)
                 continue
             } else {
@@ -845,8 +844,8 @@ private func Verify(array: [Any], againstArray expectedArray: [Any]) throws {
             }
         }
         
-        if let expectedNestedArray = expectedValue as? [AnyObject] {
-            if let actualNestedArray = actualValue as? [AnyObject] {
+        if let expectedNestedArray = expectedValue as? [Any] {
+            if let actualNestedArray = actualValue as? [Any] {
                 try Verify(array: actualNestedArray, againstArray: expectedNestedArray)
                 continue
             } else {

--- a/Wrap.podspec
+++ b/Wrap.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Wrap"
-  s.version      = "1.1.1"
+  s.version      = "2.0"
   s.summary      = "The easy to use Swift JSON encoder"
   s.description  = <<-DESC
   Wrap is an easy to use Swift JSON encoder. Don't spend hours writing JSON encoding code - just wrap it instead!
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.10"
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
-  s.source       = { :git => "https://github.com/JohnSundell/Wrap.git", :tag => "1.1.1" }
+  s.source       = { :git => "https://github.com/JohnSundell/Wrap.git", :tag => "2.0" }
   s.source_files  = "Sources/Wrap.swift"
   s.framework  = "Foundation"
 end

--- a/Wrap.xcodeproj/project.pbxproj
+++ b/Wrap.xcodeproj/project.pbxproj
@@ -257,12 +257,15 @@
 					};
 					52D6D9E11BEFFF6E002C0205 = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 					52D6D9EF1BEFFFBE002C0205 = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 					52D6DA0E1BF000BD002C0205 = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -550,6 +553,7 @@
 				PRODUCT_NAME = Wrap;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -571,6 +575,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -591,6 +596,7 @@
 				PRODUCT_NAME = Wrap;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -612,6 +618,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -636,6 +643,7 @@
 				PRODUCT_NAME = Wrap;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -659,6 +667,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Wrap.xcodeproj/project.pbxproj
+++ b/Wrap.xcodeproj/project.pbxproj
@@ -244,14 +244,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "John Sundell";
 				TargetAttributes = {
 					52D6D97B1BEFF229002C0205 = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 					52D6D9851BEFF229002C0205 = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 					};
 					52D6D9E11BEFFF6E002C0205 = {
 						CreatedOnToolsVersion = 7.1;
@@ -482,6 +484,7 @@
 				PRODUCT_NAME = Wrap;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -501,6 +504,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.unbox.Wrap-iOS";
 				PRODUCT_NAME = Wrap;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -513,6 +518,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.unbox.UnboxTests;
 				PRODUCT_NAME = Wrap;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -524,6 +530,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.unbox.UnboxTests;
 				PRODUCT_NAME = Wrap;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -562,6 +570,7 @@
 				PRODUCT_NAME = Wrap;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -602,6 +611,7 @@
 				PRODUCT_NAME = Wrap;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -648,6 +658,7 @@
 				PRODUCT_NAME = Wrap;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};

--- a/Wrap.xcodeproj/xcshareddata/xcschemes/Wrap-OSX.xcscheme
+++ b/Wrap.xcodeproj/xcshareddata/xcschemes/Wrap-OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Wrap.xcodeproj/xcshareddata/xcschemes/Wrap-iOS.xcscheme
+++ b/Wrap.xcodeproj/xcshareddata/xcschemes/Wrap-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Wrap.xcodeproj/xcshareddata/xcschemes/Wrap-tvOS.xcscheme
+++ b/Wrap.xcodeproj/xcshareddata/xcschemes/Wrap-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Wrap.xcodeproj/xcshareddata/xcschemes/Wrap-tvOS.xcscheme
+++ b/Wrap.xcodeproj/xcshareddata/xcschemes/Wrap-tvOS.xcscheme
@@ -32,9 +32,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "52D6D9F81BEFFFBE002C0205"
-               BuildableName = "Unbox-tvOSTests.xctest"
-               BlueprintName = "Unbox-tvOSTests"
+               BlueprintIdentifier = "52D6D9851BEFF229002C0205"
+               BuildableName = "Wrap.xctest"
+               BlueprintName = "WrapTests"
                ReferencedContainer = "container:Wrap.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Wrap.xcodeproj/xcshareddata/xcschemes/Wrap-watchOS.xcscheme
+++ b/Wrap.xcodeproj/xcshareddata/xcschemes/Wrap-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Wrap.xcodeproj/xcshareddata/xcschemes/WrapTests.xcscheme
+++ b/Wrap.xcodeproj/xcshareddata/xcschemes/WrapTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This PR is the proposal for a 2.0 release of Wrap, which is the release that will bring `master` onto Swift 3 (compatibility with Swift 2.x will be kept through the `1.1.1` release). It contains the contents of the `swift3` branch, as well as some API refinements, improvement suggestions & fixes for opened issues:
- `Wrap(..)` is now `wrap(..)`
- `Wrap(objects:)` is now `wrap()`
- `keyForWrapping(propertyName:)` is now `keyForWrapping(propertyNamed:)`
- `WrapCustomizable.wrap()` is now `wrap(context:dateFormatter:)`
- `wrap(propertyName:originalValue:)` is now `wrap(propertyNamed:originalValue:context:dateFormatter:)`
- All enums use a lower case leading character
- Wrapping to `snake_case` is now supported (`myProperty ->`my_property`)
- Int64 & UInt64 are now encoded properly on 32 bit systems
- Date Formatters are now kept througout the entire wrapping process, and can be used in customized wrapping
- Wrap now has support for contextual objects just like Unbox has (send `context:`) when initiating the wrapping
