### PR TITLE
Fix SPM unsupported package layout issue by excluding the test directory.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 import PackageDescription
 
 let package = Package(
-    name: "Wrap"
+    name: "Wrap",
+    exclude: ["Tests"]
 )


### PR DESCRIPTION
> swift build

    error: the package has an unsupported layout, unexpected source file(s) found: /Packages/Wrap-2.0.1/Tests/WrapTests.swift

Just as was done with the Unbox project, add Tests to the package exclude list in the Package.swift manifest file.