### PR TITLE
JSON friendly representation of dictionaries

### DIFF
--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -30,6 +30,26 @@ import Foundation
 /// Type alias defining what type of Dictionary that Wrap produces
 public typealias WrappedDictionary = [String : Any]
 
+// Extension used to get a JSON formatted description
+extension Dictionary where Key: ExpressibleByStringLiteral, Value: Any {
+    
+    /// A string that represents the contents of the dictionary in JSON syntax
+    public var prettyJsonDescription: String {
+        var prettyDescription = ""
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: self, options: .prettyPrinted)
+            if let theJsonText = String(data: jsonData, encoding: .ascii) {
+                prettyDescription += theJsonText
+            } else {
+                prettyDescription += "Error converting Data object into String"
+            }
+        } catch {
+            prettyDescription += "Error retrieving Data object: \(error)"
+        }
+        return prettyDescription
+    }
+}
+
 /**
  *  Wrap any object or value, encoding it into a JSON compatible Dictionary
  *


### PR DESCRIPTION
Adding an extension for `[String : Any]` dictionaries implements a String variable with a JSON representation of the dictionary, if it is possible.

This has been very handy for me to compare models in runtime with JSON files.

If this doesn't fit with the Framework philosophy or is more a "dongle" to the Wrap Framework than an useful feature this PR can be ejected. No hard feelings :)