### PR TITLE
Remove unneeded "Some"/.some case check for optionals

### DIFF
--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -512,7 +512,7 @@ private extension Wrapper {
                     continue
                 }
                 
-                guard let propertyName = property.label, propertyName != "Some" else {
+                guard let propertyName = property.label else {
                     continue
                 }
                 

--- a/Tests/WrapTests/WrapTests.swift
+++ b/Tests/WrapTests/WrapTests.swift
@@ -64,6 +64,21 @@ class WrapTests: XCTestCase {
         }
     }
 
+    func testSpecificNonOptionalProperties() {
+        struct Model {
+            let some: String = "value"
+            let Some: Int = 1
+        }
+
+        do {
+            try verify(dictionary: wrap(Model()), againstDictionary: [
+                "some" : "value",
+                "Some" : 1
+                ])
+        } catch {
+            XCTFail(error.toString())
+        }
+    }
     func testProtocolProperties() {
         struct NestedModel: MockProtocol {
             let constantString = "Another string"


### PR DESCRIPTION
Additional check for "Some" value, which was added possibly for handling 2.x Swift version. Doesn't make sense now, and can occasionally filter out some fields