### PR TITLE
Use globally NSRegularExpression to avoid build error on Linux

### DIFF
--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -261,7 +261,7 @@ public extension WrapCustomizable {
 public extension WrapCustomizable {
     /// Convert a given property name (assumed to be camelCased) to snake_case
     func convertPropertyNameToSnakeCase(propertyName: String) -> String {
-        let regex = try! RegularExpression(pattern: "(?<=[a-z])([A-Z])|([A-Z])(?=[a-z])", options: [])
+        let regex = try! NSRegularExpression(pattern: "(?<=[a-z])([A-Z])|([A-Z])(?=[a-z])", options: [])
         let range = NSRange(location: 0, length: propertyName.characters.count)
         let camelCasePropertyName = regex.stringByReplacingMatches(in: propertyName, options: [], range: range, withTemplate: "_$1$2")
         return camelCasePropertyName.lowercased()
@@ -566,10 +566,3 @@ extension Optional : WrapOptional {
         }
     }
 }
-
-
-// MARK: - Cross platform compatibility
-
-#if !os(Linux)
-private typealias RegularExpression = NSRegularExpression
-#endif


### PR DESCRIPTION
To avoid compatibility errors with Linux I substituted `RegularExpression` with `NSRegularExpression`. This update it's necessary because RegularExpression is not part of the open source Swift version of Foundation as reported in Marathon [issue37](https://github.com/JohnSundell/Marathon/issues/37).

I have only one doubt: 
in `Wrap.swift` there was an OS check for this issue
```swift
#if !os(Linux)
private typealias RegularExpression = NSRegularExpression
#endif
```
but for some reason he did not work.

@JohnSundell there was a specific reason to use RegularExpression instead of NSRegularExpression?
I don't want that there are some relation with the 4 test errors I reported in the comment of [issue37](https://github.com/JohnSundell/Marathon/issues/37).

I edited and tested the Linux implementation on a Vmware virtual machine with Ubuntu 16.04.2 and on a Raspberry Pi with Ubuntu 16.04.2. All the tests are ✅ also on a macOS machine.