### PR TITLE
Remove redundant Hashable conformance

### DIFF
--- a/Sources/Wrap.swift
+++ b/Sources/Wrap.swift
@@ -463,7 +463,7 @@ private extension Wrapper {
         return wrappedArray
     }
     
-    func wrap<K: Hashable, V>(dictionary: [K : V]) throws -> WrappedDictionary {
+    func wrap<K, V>(dictionary: [K : V]) throws -> WrappedDictionary {
         var wrappedDictionary = WrappedDictionary()
         let wrapper = Wrapper(context: self.context, dateFormatter: self.dateFormatter)
         


### PR DESCRIPTION
This is a new warning in Swift 3.2 on Xcode 9