### PR TITLE
Use Swift 4 version of the Package Description API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,26 @@
+// swift-tools-version:4.0
+
+/**
+ *  Wrap
+ *  Copyright (c) John Sundell 2017
+ *  Licensed under the MIT license. See LICENSE file.
+ */
+
 import PackageDescription
 
 let package = Package(
-    name: "Wrap"
+    name: "Wrap",
+    products: [
+        .library(name: "Wrap", targets: ["Wrap"])
+    ],
+    targets: [
+        .target(
+            name: "Wrap",
+            path: "Sources"
+        ),
+        .testTarget(
+            name: "WrapTests",
+            dependencies: ["Wrap"]
+        )
+    ]
 )


### PR DESCRIPTION
To tell SPM to compile the project using Swift 4.