### PR TITLE
Added ability to fallback nil values

### DIFF
--- a/Tests/WrapTests/WrapTests.swift
+++ b/Tests/WrapTests/WrapTests.swift
@@ -709,6 +709,37 @@ class WrapTests: XCTestCase {
         }
     }
 
+    func testFallbackValueCustomization() {
+        struct Model: WrapCustomizable {
+            let string = "A string"
+            let optional: String? = nil
+            let optionalTwo: Int? = nil
+            let skipThisOptional: String? = nil
+
+            fileprivate func fallbackValueForProperty(propertyNamed propertyName: String) -> Any? {
+                if propertyName == "optional" {
+                    return "null"
+                }
+
+                if propertyName == "optionalTwo" {
+                    return 10
+                }
+
+                return nil
+            }
+        }
+
+        do {
+            try verify(dictionary: wrap(Model()), againstDictionary: [
+                "string" : "A string",
+                "optional" : "null",
+                "optionalTwo" : 10
+            ])
+        } catch {
+            XCTFail(error.toString())
+        }
+    }
+
     func testCustomWrapping() {
         struct Model: WrapCustomizable {
             let string = "A string"


### PR DESCRIPTION
This is the reborn of #36, as it was closed and I think it is relevant. Some APIs require sending `null` values for properties, this approach is interesting because keep the JSON clean and you can only override the ones you need.

Like:

```swift
struct Image: WrapCustomizable {
    let name
    let path: String?

    fileprivate func fallbackValueForProperty(propertyNamed propertyName: String) -> Any? {
        if propertyName == "path" {
            return NSNull()
        }
        return nil
    }
}
```

will wrap to a JSON like this:
```javascript
{
    "name": "image.jpg",
    "path": null
}
```