### PR TITLE
Fix tests on Swift 4.2

### DIFF
--- a/Tests/WrapTests/WrapTests.swift
+++ b/Tests/WrapTests/WrapTests.swift
@@ -173,7 +173,9 @@ class WrapTests: XCTestCase {
                     "second" : "Hello"
                 ],
                 "third" : [
-                    "third" : 15
+                    "third" : [
+                        "intValue" : 15
+                    ]
                 ],
                 "firstInt" : 0,
                 "secondInt" : 17,


### PR DESCRIPTION
This PR fixes the `testEnumProperties` test on Swift 4.2. It fixes half of #56. However, I couldn't figure out how to fix `testMixedNSObjectSetProperty`. I identified the following problems with it, but wasn't sure what to do:
- The set can be wrapped out of order
- `8.3 as NSObject` is wrapped as `8.300000000000001`, and so can't be verified